### PR TITLE
Fix export of symbols on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - fix-osx-rpath.patch
+    - windows.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('qhull', max_pin='x.x') }}
 

--- a/recipe/windows.patch
+++ b/recipe/windows.patch
@@ -1,0 +1,32 @@
+diff --git a/src/libqhull_r/qhull_r-exports.def b/src/libqhull_r/qhull_r-exports.def
+index 4c5e17c..415f7a9 100644
+--- a/src/libqhull_r/qhull_r-exports.def
++++ b/src/libqhull_r/qhull_r-exports.def
+@@ -1,9 +1,9 @@
+ ; qhull_r-exports.def -- MSVC module-definition file
+ ;
+ ;   Generated from depends.exe by cut-and-paste of exported symbols by mingw gcc
+-;   [jan'14] 391 symbols 
++;   [jan'14] 391 symbols
+ ;
+-;   Referenced by CMakeLists/add_library, libqhull_r.pro/DEF_FILE, 
++;   Referenced by CMakeLists/add_library, libqhull_r.pro/DEF_FILE,
+ ;   and libqhull_r.vcxproj/Linker/Input/Module Definition File
+ ;
+ ;   If qh_NOmerge, use qhull_r-nomerge-exports.def
+@@ -183,6 +183,7 @@ qh_maxouter
+ qh_maxsimplex
+ qh_maydropneighbor
+ qh_memalloc
++qh_memcheck
+ qh_memfree
+ qh_memfreeshort
+ qh_meminit
+@@ -351,6 +352,7 @@ qh_setdelnth
+ qh_setdelnthsorted
+ qh_setdelsorted
+ qh_setduplicate
++qh_setendpointer
+ qh_setequal
+ qh_setequal_except
+ qh_setequal_skip


### PR DESCRIPTION
Related to https://github.com/qhull/qhull/pull/93

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
